### PR TITLE
replaced run-shell-command

### DIFF
--- a/main.lisp
+++ b/main.lisp
@@ -25,4 +25,4 @@
 
 (sb-thread::make-thread (lambda () (progn
 			  (sleep 1)
-			  (asdf:run-shell-command "explorer http://localhost:9099")))) ;open webbrowser (for windows only)
+			  (uiop:run-program "explorer http://localhost:9099")))) ;open webbrowser (for windows only)


### PR DESCRIPTION
I replaced from asdf:run-shell-command to uiop:run-program.
Because, this kind of warning comes out.

```common-lisp
WARNING:
   DEPRECATED-FUNCTION-STYLE-WARNING: Using deprecated function ASDF/BACKWARD-INTERFACE:RUN-SHELL-COMMAND -- please update your code to use a newer API.
The docstring for this function says:
PLEASE DO NOT USE. This function is not just DEPRECATED, but also dysfunctional.
Please use UIOP:RUN-PROGRAM instead.
```